### PR TITLE
Fix url forging issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,47 @@ For the moment, this contains, as a JSON file, the list of French towns involved
 
 ## **Main Files**
 ### `adzuna.py`
-To extract dumps from different endpoints from Adzuna API.
+This module contains functions devoted to extract dumps from different endpoints from Adzuna API:
+#### 🛠️ `get_adzuna_ads`
+##### **OVERVIEW**
+
+This function allows to call the API in order to **find relevant information about ads**, the endpoint used being `GET jobs/{country}/search/{page}`
+It can be seen as a daily tool which will try to fetch as many ads as possible:
+- calling for **1 related page, containing 50 results**,
+- playing around the rate-limit of 25 calls per min,
+- **theorically** proceeding to **up to 250 calls** (daily rate limit),
+- **evaluating if the aggregated response contains too many duplicates** (checked on the **`id`** field, which a threshold ratio set inside the function via the **`THRESHOLD`** constant) and then **stopping the fetching whenever it occurs**.
+
+🔎 *Experiments lead to notice that duplicates tend to often appear after featching 100 pages, meaning you're still far from the theorical limit*.
+
+##### **PARAMETERS**
+
+Both being optional, they allow to narrow the scope of search
+- `what`: the keywords to search for (multiple items may be space separated)
+- `cat_tag`: the category tag, as returned by the `category` endpoint (read below)
+
+##### **RETURN VALUES**
+
+It returns a `tuple` containing:
+- A list of `AdzunaJob` objects, as defined in `data_models.py`
+- The number of remaining calls for the day.
+
+##### **EXAMPLES OF USE**
+> ❌ **TO DO**
+
+#### 🛠️ `get_adzuna_cats`
+
+This function requests the API to get a list of existing categories, the used endpoint being `GET jobs/{country}/categories`.
+> ❌ **DEVELOP**
+
+#### 🛠️ `get_adzuna_locs`
+
+This function requests the API to get salary data for locations inside an area, the used endpoint being `GET jobs/{country}/geodata`
+> ❌ **DEVELOP**
+
+#### 🛠️ `dump_adzuna_jobs`
+
+This function allows to dump ads transformed data from the API to be stored in JSON format in the `data` folder.
 
 ### `the_muse.py`
 Same as previously, but for The Muse API.

--- a/adzuna.py
+++ b/adzuna.py
@@ -6,120 +6,120 @@ Endpoints already implemented are those corresponding to
 - locations
 """
 
-
 import json
 import time
+from typing import List, Optional, Tuple
 
-import httpx
+from httpx import Client
 from rich import print
 
+from data_models import AdzunaJob, model_adzuna_job_data
 from utils import configure, create_client, get_timestamp, timer
 
 
-@timer
-def get_adzuna_ads_page(client: httpx.Client,
+def dump_adzuna_jobs(jobs: List[AdzunaJob]) -> None:
+    """Dump data selected from Adzuna API response in a JSON file in data folder"""
+    ts = get_timestamp()
+    dump_path = f'data/adzuna_jobs_{ts}.json'
+    # Converting AdzunaJob objects to dumpable dicts with pydantic method
+    dumpable_jobs = [job.model_dump() for job in jobs]
+    with open(dump_path, 'w', encoding='utf-8') as dump_file:
+        # `ensure_ascii=False` to force display of non-ascii characters in JSON
+        json.dump(dumpable_jobs, dump_file, indent=4, ensure_ascii=False) 
+    print(f'\t[cyan]{dump_path} dumped![/cyan]')
+    
+
+def get_adzuna_ads_page(client: Client,
                         page: int,
-                        cat_tag: str = 'it-jobs'):  # Update output annotation
-    """
-    Get the 50 results of one page from Azuna API.
-    """
+                        what: Optional[str] = None,
+                        cat_tag: Optional[str] = None) -> List[dict]:
+    """Get the 50 results of one page from Adzuna API"""
     url = f'{ADZUNA_URL}/jobs/fr/search/{page}'
+    custom_params = {
+        'app_id': ADZUNA_ID,
+        'app_key': ADZUNA_KEY,
+        'results_per_page': 50
+        }
+    if what:
+        custom_params['what'] = what
+    if cat_tag:
+        custom_params['category'] = cat_tag
     
     resp = client.get(
         url,
-        params = {
-            'app_id': ADZUNA_ID,
-            'app_key': ADZUNA_KEY,
-            'results_per_page': 50,
-            'category': cat_tag 
-        }
+        params=custom_params
     )
     resp.raise_for_status()
+    
     return resp.json()['results']
-    
-
-@timer
-def get_adzuna_ads(cat_tag: str = 'it-jobs',
-                   nb_pages: int = 25) -> None:
-    """
-    Get all job ads from Adzuna API.
-    The rate limit enforces 25 requests per minute
-    """
-    cli = create_client()
-    adzuna_jobs = {}
-    adzuna_jobs['results'] = []
-    errors = 0
-    
-    # Query Loop    
-    for page in range(1, nb_pages + 1):    
-        try:
-            adzuna_jobs['results'].extend(get_adzuna_ads_page(cli, page, cat_tag))
-            print(f'Page {page} PROCESSED')
-        except BaseException as e:
-            print(f'[red]{type(e)}: Exception {e} occured![/red] on page {page}')
-            errors += 1
-    print(f'\t[yellow]{nb_pages - errors} pages succesfully processed.[/yellow]')
-
-    # Dump Results
-    ts = get_timestamp()
-    adzuna_jobs['created_at'] = ts
-    dump_path = f'data/adzuna_jobs_{ts}.json'
-    with open(dump_path, 'w', encoding='utf-8') as dump_file:
-        # Last parameter `ensure_ascii` to force display of non-ascii characters
-        json.dump(adzuna_jobs, dump_file, indent=4, ensure_ascii=False) 
-    print(f'\t[cyan]{dump_path} dumped![/cyan]')
-    
-    return adzuna_jobs
 
 
 @timer
-def get_daily_adzuna_ads(cat_tag: str = 'it-jobs'):
+def get_adzuna_ads(what: Optional[str] = None,
+                   cat_tag: str = 'it-jobs')-> Tuple[List[AdzunaJob], int]:
     """
-    Get all job ads from Adzuna API, on a daily basis:
-    After careful study, if you want to avoid systematical duplicates,
-    it corresponds to 100 pages, with 50 ads per page, hence 5 000 ads.    
+    Requesting Adzuna API to get as much as possible relevant daily ads
+    Parameters
+    ----------
+        - what: a topic to explore ('data', 'Python' for example)
+        - cat_tag: a custom category tag from Adzuna (read the doc)
+    Returns
+    -------
+        A 2-tuple with:
+        - A list of AdzunaJob objects
+        - The number of remaining daily calls  
     """
+    THRESHOLD = 0.05  # tolerated duplicates ratio
+    
     cli = create_client()
-    adzuna_jobs = {}
-    adzuna_jobs['results'] = []
+    adzuna_jobs = []
     errors = 0
     n_page = 1
+    duplicates = []
     
-    for step in range(1, 5):
+    for step in range(1, 11):
         print(f"\t[white]Step {step}[/white]")
         for page in range(n_page, n_page + 25):
+            # UPDATING 'id' SET
+            ids = set(job['id'] for job in adzuna_jobs)
             # REQUESTING
             try:
-                adzuna_jobs['results'].extend(get_adzuna_ads_page(cli, page, cat_tag))
-                print(f'Page {page} PROCESSED')
+                new_jobs = get_adzuna_ads_page(cli, page, what, cat_tag)
+                print(f'Page {page} PROCESSED')    
             except BaseException as e:
                 print(f'[red]{type(e)}: Exception {e} occured![/red] on page {page}')
-                errors += 1   
+                errors += 1    
+            else:
+                duplicates.extend([job['id'] for job in new_jobs if job['id'] in ids])
+                adzuna_jobs.extend(new_jobs)
+                dupl_ratio = len(duplicates) / len(adzuna_jobs)
+                print(f'[cyan]=> DUPLICATES RATIO: {dupl_ratio:.2f}[cyan]')
+                if dupl_ratio > THRESHOLD:
+                    print("\t[orange]EXIT FOR DUPLICATES[/orange]")
+                    print(f'\t[yellow]{page - errors} pages succesfully processed.[/yellow]')
+                    remaining_calls = 250 - page
+                    print(f"\t[yellow]{remaining_calls} remaining calls[/yellow]")
+                    
+                    return model_adzuna_job_data(adzuna_jobs), remaining_calls            
         # GOING OUT FROM STEP
-        n_page += 25    # Updating number of first page
-        if step < 4:
-            time.sleep(61)  # Going around minute rate limit
+        n_page += 25  # Updating the first page to begin with
+        if step < 10:
+            time.sleep(60)  # Going around minute rate limit
+            print('*** WAITING FOR 60 S ***')
+            
+        
+    # FULL PROCESS SUM-UP
+    print(f'\t[yellow]{n_page - 1 - errors} pages succesfully processed.[/yellow]')
+    print(f"\t[yellow]0 remaining calls[/yellow]")
     
-    # SUM-UP
-    print(f'\t[yellow]{n_page -1 - errors} pages succesfully processed.[/yellow]')
-    
-    # DUMPING RESULTS
-    ts = get_timestamp()
-    adzuna_jobs['created_at'] = ts
-    dump_path = f'data/adzuna_jobs_{ts}.json'
-    with open(dump_path, 'w', encoding='utf-8') as dump_file:
-        # `ensure_ascii=False` to force display of non-ascii characters in JSON
-        json.dump(adzuna_jobs, dump_file, indent=4, ensure_ascii=False) 
-    print(f'\t[cyan]{dump_path} dumped![/cyan]')
-    
-    return adzuna_jobs
-
-
+    return model_adzuna_job_data(adzuna_jobs), 0
+ 
+ 
 @timer
 def get_adzuna_cats() -> dict:
     """
-    Get categories from Adzuna.
-    Save it, in data folder in a .json file.
+    Get categories from Adzuna API.
+    Save it, in data folder in a JSON file.
     Return a corresponding dict
     """
     url = f'{ADZUNA_URL}/jobs/fr/categories'
@@ -132,64 +132,75 @@ def get_adzuna_cats() -> dict:
         }
     )
     
-    json_resp = resp.json()
-    
-    ts = get_timestamp()
-    with open(f'data/adzuna_cats_{ts}.json',
-              'w', encoding='utf-8') as resp_file:
-        # Last parameter `ensure_ascii` to force display of non-ascii characters
-        json.dump(json_resp, resp_file, indent=4, ensure_ascii=False)
-        
-    # print(f'[yellow]{resp.headers}[/yellow]')
-    
-    return json_resp
-    
-
-@timer
-def get_adzuna_locs(cat_tag: str = 'it-jobs') -> dict:
-    """
-    Get salary data for locations in France,
-    corresponding to the default cat_tag 'it-jobs'.
-    Save it, in data folder in a json file.
-    Return a corresponding dict
-    """
-    url = f'{ADZUNA_URL}/jobs/fr/geodata'
-    cli = create_client()
-    resp = cli.get(
-        url,
-        params = {
-            'app_id': ADZUNA_ID,
-            'app_key': ADZUNA_KEY,
-            'category': cat_tag
-        }
-    )
     resp.raise_for_status()
-    json_resp = resp.json()
+    cats = resp.json()['results']
+    for cat in cats:
+        try:
+            del cat['__CLASS__']
+        except KeyError:
+            pass
     
     ts = get_timestamp()
-    with open(f'data/adzuna_locs_{cat_tag}_{ts}.json',
-              'w', encoding='utf-8') as resp_file:
-        # Last parameter `ensure_ascii` to force display of non-ascii characters
-        json.dump(json_resp, resp_file, indent=4, ensure_ascii=False)
-        
-    # print(f'[yellow]{resp.headers}[/yellow]')
+    with open(f'data/adzuna_cats_{ts}.json', 'w', encoding='utf-8') as dump_file:
+        # `ensure_ascii` to force display of non-ascii characters
+        json.dump(cats, dump_file, indent=4, ensure_ascii=False)
     
-    return json_resp
+    return cats
+ 
+
+# # 🚸 SHOULD WE KEEP THIS? THIS HAS TO BE REWORKED 🚸
+# @timer
+# def get_adzuna_locs(cat_tag: str = 'it-jobs') -> dict:
+#     """
+#     Get salary data for locations in France,
+#     corresponding to the default cat_tag 'it-jobs'.
+#     Save it, in data folder in a json file.
+#     Return a corresponding dict
+#     """
+#     url = f'{ADZUNA_URL}/jobs/fr/geodata'
+#     cli = create_client()
+#     resp = cli.get(
+#         url,
+#         params = {
+#             'app_id': ADZUNA_ID,
+#             'app_key': ADZUNA_KEY,
+#             'category': cat_tag
+#         }
+#     )
+#     resp.raise_for_status()
+#     json_resp = resp.json()
+    
+#     ts = get_timestamp()
+#     with open(f'data/adzuna_locs_{cat_tag}_{ts}.json',
+#               'w', encoding='utf-8') as dump_file:
+#         # `ensure_ascii` to force display of non-ascii characters
+#         json.dump(json_resp, dump_file, indent=4, ensure_ascii=False)
+    
+#     return json_resp
 
 
 if __name__ == '__main__':
-    ADZUNA_URL, ADZUNA_ID, ADZUNA_KEY, _, _ = configure()  
-    
-    # Test get_daily_adzuna_ads
-    get_daily_adzuna_ads()
-    
-    # # Test get_adzuna_ads
-    # get_adzuna_ads()
-    
-    # # Test get_adzuna_cats
-    # get_adzuna_cats()
+    ADZUNA_URL, ADZUNA_ID, ADZUNA_KEY, _, _ = configure()
     
     # # Test get_adzuna_locs
-    # locs = get_adzuna_locs()
-    # print(locs)
-    # print(type(locs))
+    # l = get_adzuna_locs()
+    # print(l)
+    
+    # # Test get_adzuna_cats
+    # c = get_adzuna_cats()
+    # print(c)
+    
+    # Test get_adzuna_ads and dump_adzuna_jobs
+    jobs, remaining_calls = get_adzuna_ads(what='data')
+    dump_adzuna_jobs(jobs)
+    
+    # # Test get_adzuna_ads_page
+    # cli = create_client()
+    # ad = get_adzuna_ads_page(cli, 1, what='data', cat_tag='it-jobs')
+    # print(ad) 
+    # ts = get_timestamp()
+    # dump_path = f'data/adzuna_page_test_{ts}.json'
+    # with open(dump_path, 'w', encoding='utf-8') as dump_file:
+    #     # `ensure_ascii=False` to force display of non-ascii characters in JSON
+    #     json.dump(ad, dump_file, indent=4, ensure_ascii=False) 
+    # print(f'\t[cyan]{dump_path} dumped![/cyan]')

--- a/adzuna.py
+++ b/adzuna.py
@@ -76,9 +76,8 @@ def get_adzuna_ads(cat_tag: str = 'it-jobs',
 def get_daily_adzuna_ads(cat_tag: str = 'it-jobs'):
     """
     Get all job ads from Adzuna API, on a daily basis:
-    - the daily rate being 250
-    - the number of ads by page being 20
-    This corresponds, to the max, to 5 000 ads.    
+    After careful study, if you want to avoid systematical duplicates,
+    it corresponds to 100 pages, with 50 ads per page, hence 5 000 ads.    
     """
     cli = create_client()
     adzuna_jobs = {}
@@ -86,7 +85,7 @@ def get_daily_adzuna_ads(cat_tag: str = 'it-jobs'):
     errors = 0
     n_page = 1
     
-    for step in range(1, 11):
+    for step in range(1, 5):
         print(f"\t[white]Step {step}[/white]")
         for page in range(n_page, n_page + 25):
             # REQUESTING
@@ -98,7 +97,8 @@ def get_daily_adzuna_ads(cat_tag: str = 'it-jobs'):
                 errors += 1   
         # GOING OUT FROM STEP
         n_page += 25    # Updating number of first page
-        time.sleep(61)  # Going around minute rate limit
+        if step < 4:
+            time.sleep(61)  # Going around minute rate limit
     
     # SUM-UP
     print(f'\t[yellow]{n_page -1 - errors} pages succesfully processed.[/yellow]')

--- a/hw_scraper.py
+++ b/hw_scraper.py
@@ -1,0 +1,209 @@
+"""
+This module contains logic to scrape data from HelloWork ad pages,
+the output being a devoted Pydantic class.
+
+IMPORTANT:
+For the moment, this is a module, not a script.
+It means that you have to import, at least,
+the final function `scrape_hw` to implement it into your workflow.
+"""
+
+
+from typing import List, Optional
+
+from bs4 import BeautifulSoup
+from pydantic import BaseModel
+import requests
+from rich import print
+
+
+USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)\
+    AppleWebKit/537.36 (KHTML, like Gecko)\
+        Chrome/116.0.0.0 Safari/537.36'
+URL = '<Enter your URL here>'
+
+
+# Classes, by order of appearance in the code
+class HelloWorkSumUp(BaseModel):
+    """Output class from `get_hw_sum_up`function"""
+    location: str
+    contract: str
+    duration: Optional[str]
+    remote: Optional[str]
+    education: Optional[List[str]]
+    experience: Optional[List[str]]
+    sectors: Optional[List[str]]
+
+
+class HelloWorkSalary(BaseModel):
+    """Output class from `get_hw_salary` function"""
+    salary_min: Optional[str]
+    salary_med: Optional[str]
+    salary_max: Optional[str]
+    
+
+class HelloWorkAd(BaseModel):
+    """Output class for a HelloWord scraped ad"""
+    id: str   # Given by adzuna_url's output
+    url: str 
+    location: str
+    contract: str
+    duration: Optional[str]  
+    remote: Optional[str]       
+    education: Optional[List[str]]
+    experience: Optional[List[str]]
+    sectors: Optional[List[str]]
+    description: str
+    salary_min: Optional[str]
+    salary_med: Optional[str]
+    salary_max: Optional[str]
+    
+
+# Function, by order of appearance in the code
+def load_and_parse(url: str) -> BeautifulSoup:
+    """Load (requests) and parse (BeautifulSoup)"""
+    resp = requests.get(url, headers={'User-Agent': USER_AGENT})
+    if resp.status_code != 200:
+        print(f"{resp.reason = }")
+        
+    return BeautifulSoup(resp.text, 'html.parser')
+
+
+def is_ad_outdated(html: BeautifulSoup) -> bool:
+    """
+    Check if there's a `span` tag with class `warning`.
+    Its text is generally: "Cette offre d'emploi a été pourvue"
+    """
+    return html.find("span", {'class': 'warning'})
+
+
+def get_hw_sum_up(html: BeautifulSoup) -> Optional[HelloWorkSumUp]:
+    """Get information contained in HelloWork's page sum-up"""
+    sum_up = html.find_all('section')[-1]  # Sum-up is always the last section
+    
+    # Mandatory two first tags with: `location` and `contract` fields
+    two_first_tags = sum_up.find_all('li', {'class': 'tw-tag-contract-s'})    
+    location = two_first_tags[0].text.strip()
+    contract = two_first_tags[1].text.strip()
+    
+    # Other tags with remaining fields
+    other_tags = sum_up.find_all('li', {'class': 'tw-tag-primary-s'})
+    other_fields = set(tag.text.strip() for tag in other_tags)
+    # duration
+    duration = None
+    for field in other_fields:
+        if field.startswith('\U0001F551'):
+            duration = field[2:]
+            other_fields.remove(field)
+            break
+    # remote
+    remote = None  # Default value
+    for field in other_fields:
+        if field.startswith(u'\U0001F3E0'):
+            remote = field[2:]
+            other_fields.remove(field)
+            break
+    # education
+    education = [field for field in other_fields
+                 if field.startswith('Bac')]
+    for level in education:
+        other_fields.remove(level)
+    # experience
+    experience = [field for field in other_fields
+                  if field.startswith('Exp.')]
+    for level in experience:
+        other_fields.remove(level)
+    # sectors (remaining items if everything is ok)
+    sectors = sorted(list(other_fields))
+
+    return HelloWorkSumUp(
+        location=location,
+        contract=contract,
+        duration=duration,
+        remote=remote,
+        education=education, 
+        experience=experience,
+        sectors=sectors
+    )
+
+
+def get_hw_salary(html: BeautifulSoup) -> HelloWorkSalary:
+    """Get salary information from HelloWork's page"""
+    # Searchin within sum_up
+    sum_up = html.find_all('section')[-1]
+    if (result := sum_up.find('li', {'class': 'tw-tag-attractive-s'})) is not None:
+        # Salary in sum_up
+        output = (result
+                  .text.strip()
+                  .replace('\u202f', '').replace(' - ', ' ').replace('EUR', '€')
+                  .split()
+                 )
+        salary_max = " ".join(output[1:])
+        del output[1]
+        salary_min = " ".join(output)
+        
+        return HelloWorkSalary(
+            salary_min = salary_min,
+            salary_med = None,
+            salary_max = salary_max
+            )
+    else:
+        # Salary to search in salary section
+        salaries = dict()
+        cats = ('low', 'median', 'high')
+        for cat in cats:
+            if (s := html.find('p', {'data-cy': f'{cat}Estimation'})) is not None:
+                salaries[cat] = s.text.replace('\u202f', '')
+            else:
+                salaries[cat] = None
+                
+        return HelloWorkSalary(
+            salary_min = salaries['low'],
+            salary_med = salaries['median'],
+            salary_max = salaries['high']
+        )
+
+
+def get_hw_description(html: BeautifulSoup) -> str:
+    """Get the relevant text information on HelloWork's page."""
+    keywords = ('poste', 'profil')
+    output_texts = []
+    
+    for keyword in keywords:
+        h2_tag = html.find('h2', string=lambda text: text and keyword in text.lower())
+        if h2_tag:
+            p_tag = h2_tag.find_next_sibling('p')
+            if p_tag:
+                output_texts.append(p_tag.text.strip())
+    final_text = ' '.join(output_texts)
+    
+    return final_text
+
+
+def scrape_hw(id: str, url: str) -> Optional[HelloWorkAd]:
+    """Scrape the page and return a HelloWorkAd Class"""
+    html = load_and_parse(url)
+    
+    # Initial testing if ad is outdated
+    if is_ad_outdated(html):
+        return None
+        
+    sum_up_data = get_hw_sum_up(html)    
+    salary_data = get_hw_salary(html)
+    description = get_hw_description(html)
+    
+    return HelloWorkAd(
+        id=id,
+        url=url,
+        location=sum_up_data.location,
+        contract=sum_up_data.contract,
+        duration=sum_up_data.duration,
+        remote=sum_up_data.remote,
+        education=sum_up_data.education,
+        experience=sum_up_data.experience,
+        sectors=sum_up_data.sectors,
+        description=description,
+        salary_min=salary_data.salary_min,
+        salary_med=salary_data.salary_med,
+        salary_max=salary_data.salary_max
+    )

--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,7 @@ import functools
 import os
 import re
 import time
+from typing import Tuple
 
 from dotenv import load_dotenv
 import httpx
@@ -51,16 +52,28 @@ def create_client() -> httpx.Client:
     return c
 
 
-def forge_adzuna_url(redirect_url: str) -> str:
+def forge_adzuna_url(redirect_url: str) -> Tuple[str, bool]:
     """
-    Transforms a redirecting unscrapable url
-    to an unredirecting scrapable one
+    Params
+    ------
+        redirect_url: corresponding to this field in Adzuna API's ad response
+    Returns
+    -------
+    A tuple containing:
+        - The URL of the ads webpage, being either Adzuna's one or a Job Board's one
+        - A boolean indicating if there's a redirection or not.
     """
-    _, api, source, _ = redirect_url.split('&')
-    id_ = re.search(r'\d{10}\?', redirect_url).group()
-    new_url = BASE + id_ + '&'.join([api, source])
-
-    return new_url
+    try:
+        # In this case, there's a redirection to another Job Board
+        _, api, source, _ = redirect_url.split('&')
+        id_ = re.search(r'\d{10}\?', redirect_url).group()
+        new_url = BASE + id_ + '&'.join([api, source])
+        return new_url, True
+    
+    except ValueError:
+        # In this case, redirect_url is Adzuna's page
+        # The API's terminology is poor as there's in fact NO redirection
+        return redirect_url, False
 
 
 def forge_hellowork_url(url: str) -> str:


### PR DESCRIPTION
⚠️ This fixes some serious issues detailed in issue #5 

☝️ And I think it's an opportunity to test this on fresh morning dumps of new ads.

⚠️⚠️⚠️ **CAUTION** ⚠️⚠️⚠️
Inside the `data` folder, I created a subfolder called `flow`
**It's not mandatory but then MODIFY YOUR INPUTS AND OUTPUTS WHEN CALLING `json.load` and `json.dump`**
- line 20: adjust `ads_api_path = 'data/flow/new_ads_2023-11-23_4.json'`
- line 67: adjust `dump_path = f'{ads_api_path}_urls_1.json'`

The `flow` subfolder is meant to contain:
- daily dumps of new ads (it will be automated this way, unless the team decides otherwise)
- my corresponding scrapings for urls and pages

As an example, here's how it looks for me:
![flow_folder](https://github.com/GMartin-Data/jm_project/assets/139137104/0d489fe4-f7fa-4282-91c1-6f7848d320fb)
You can find this morning's dumps and I named accordingly the output dumps for urls.
(the `_1` is only here because I proceed in two steps)

👉 Of course, it's a seemingly reasonable idea that came to my mind this morning but this isn't _written in marble_ and **we can opt for another  way to manage the flow**, I keep being open to the team's pov. 

Well, I suppose everything is ok. I didn't add a logger but the tricolor output of `rich` is, in my humble opinion, informative enough to understand what's happening.